### PR TITLE
fix: hotfix release 0.8.6 — CLI crash, proxy loop detection, hosts safety, signal handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,9 @@ jobs:
         
       - name: Test API
         run: pnpm --filter api test -- --passWithNoTests
+
+      - name: Smoke test agent CLI
+        run: |
+          cd apps/agent
+          npx tsx src/cli.ts --version
+          npx tsx src/cli.ts --help

--- a/apps/agent/package.json
+++ b/apps/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "bin": {
     "connect": "./dist/cli.js"

--- a/apps/agent/src/active-routes.ts
+++ b/apps/agent/src/active-routes.ts
@@ -82,6 +82,20 @@ function saveRoutesFile(data: ActiveRoutesFile): void {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Validation
+// ─────────────────────────────────────────────────────────────────────────────
+
+const VALID_SERVICE_NAME = /^[a-zA-Z0-9_-]+$/;
+
+function validateServiceName(name: string): void {
+  if (!VALID_SERVICE_NAME.test(name)) {
+    throw new Error(
+      `Service name "${name}" contains invalid characters. Use only letters, numbers, hyphens, and underscores.`,
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Route Management
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -93,6 +107,7 @@ export function registerRoute(
   localPort: number,
   protocol: string = 'tcp'
 ): void {
+  validateServiceName(serviceName);
   const routes = loadActiveRoutes();
 
   // Remove any existing route for the same service

--- a/apps/agent/src/cli.ts
+++ b/apps/agent/src/cli.ts
@@ -191,7 +191,8 @@ function validateDaemonAction(action: string | undefined): DaemonAction | undefi
 program
   .name('connect')
   .description('Private Connect Agent - Securely expose local services')
-  .version(VERSION);
+  .version(VERSION)
+  .enablePositionalOptions();
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Default Command - The Primitive

--- a/apps/agent/src/commands/proxy.ts
+++ b/apps/agent/src/commands/proxy.ts
@@ -457,7 +457,7 @@ async function startProxy(options: ProxyOptions) {
       port: route.port,
       path: req.url,
       method: req.method,
-      headers: { ...req.headers, ...forwardedHeaders },
+      headers: { ...req.headers, ...forwardedHeaders, [headerName]: '1' },
     }, (proxyRes) => {
       res.writeHead(proxyRes.statusCode || 500, proxyRes.headers);
       proxyRes.pipe(res);
@@ -479,6 +479,12 @@ async function startProxy(options: ProxyOptions) {
   };
 
   const handleUpgrade = (req: http.IncomingMessage, socket: net.Socket, head: Buffer) => {
+    if (req.headers[headerName]) {
+      socket.write('HTTP/1.1 508 Loop Detected\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
     const host = req.headers.host || '';
     const route = findRoute(routes, host, useWildcard);
 
@@ -487,7 +493,7 @@ async function startProxy(options: ProxyOptions) {
     const proxyReq = http.request({
       hostname: route.host, port: route.port,
       path: req.url, method: req.method,
-      headers: { ...req.headers },
+      headers: { ...req.headers, [headerName]: '1' },
     });
 
     proxyReq.on('upgrade', (proxyRes, proxySocket, proxyHead) => {
@@ -522,6 +528,12 @@ async function startProxy(options: ProxyOptions) {
   };
 
   const handleConnect = (req: http.IncomingMessage, clientSocket: net.Socket, head: Buffer) => {
+    if (req.headers[headerName]) {
+      clientSocket.write('HTTP/1.1 508 Loop Detected\r\n\r\n');
+      clientSocket.destroy();
+      return;
+    }
+
     const [hostname] = (req.url || '').split(':');
     const route = findRoute(routes, hostname, useWildcard);
 

--- a/apps/agent/src/commands/run.ts
+++ b/apps/agent/src/commands/run.ts
@@ -70,5 +70,8 @@ export async function runCommand(name: string, cmd: string[], options: RunOption
     setTimeout(() => process.exit(0), 3000).unref();
   });
 
-  process.on('SIGTERM', cleanup);
+  process.on('SIGTERM', () => {
+    cleanup();
+    setTimeout(() => process.exit(0), 3000).unref();
+  });
 }

--- a/apps/agent/src/hosts.ts
+++ b/apps/agent/src/hosts.ts
@@ -16,18 +16,24 @@ interface HostsOptions {
 }
 
 function removeExistingBlock(content: string): string {
-  const start = content.indexOf(BEGIN_MARKER);
-  if (start === -1) return content;
-  const end = content.indexOf(END_MARKER, start);
-  if (end === -1) return content;
+  const beginRe = new RegExp(`^${escapeRegExp(BEGIN_MARKER)}$`, 'm');
+  const endRe = new RegExp(`^${escapeRegExp(END_MARKER)}$`, 'm');
 
-  let endPos = end + END_MARKER.length;
+  const startMatch = beginRe.exec(content);
+  if (!startMatch) return content;
+  const endMatch = endRe.exec(content.slice(startMatch.index));
+  if (!endMatch) return content;
+
+  let startPos = startMatch.index;
+  let endPos = startMatch.index + endMatch.index + endMatch[0].length;
   if (content[endPos] === '\n') endPos++;
-
-  let startPos = start;
   if (startPos > 0 && content[startPos - 1] === '\n') startPos--;
 
   return content.substring(0, startPos) + content.substring(endPos);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function writeWithSudo(content: string, options?: HostsOptions): boolean {
@@ -64,7 +70,13 @@ export function syncHosts(
     const current = fs.readFileSync(HOSTS_PATH, 'utf-8');
     const cleaned = removeExistingBlock(current);
 
-    const lines = entries.map(e => `${e.ip} ${e.hostname}`);
+    const sanitized = entries.filter(e =>
+      !e.hostname.includes('\n') && !e.hostname.includes('\r') &&
+      !e.ip.includes('\n') && !e.ip.includes('\r')
+    );
+    if (sanitized.length === 0) return { synced: true };
+
+    const lines = sanitized.map(e => `${e.ip} ${e.hostname}`);
     const block = `${BEGIN_MARKER}\n${lines.join('\n')}\n${END_MARKER}`;
     const newContent = cleaned.trimEnd() + '\n\n' + block + '\n';
 
@@ -90,7 +102,7 @@ export function cleanHosts(
 
   try {
     const current = fs.readFileSync(HOSTS_PATH, 'utf-8');
-    if (!current.includes(BEGIN_MARKER)) {
+    if (!new RegExp(`^${escapeRegExp(BEGIN_MARKER)}$`, 'm').test(current)) {
       return { cleaned: true };
     }
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "api",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "scripts": {
     "dev": "nest start --watch",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "scripts": {
     "dev": "nuxt dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-connect",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "description": "Private Connect - Secure tunneling for internal services",
   "packageManager": "pnpm@9.15.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "private-connect",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Access private services by name from anywhere. No VPN setup, no firewall rules. Open source alternative to ngrok and Tailscale for service-level connectivity.",
   "bin": {
     "private-connect": "dist/index.js"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@privateconnect/sdk",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "Define your connections in pconnect.yml. Access them from anywhere.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Hotfix release for five bugs introduced in v0.8.5 (`2b9bf00`). The most critical is **#74** — the CLI is completely non-functional (crashes on startup).

- **#74** — CLI crashes on startup due to missing `.enablePositionalOptions()` on parent Commander program
- **#75** — Newline injection in service names can corrupt `/etc/hosts` with entries that survive `connect hosts clean`
- **#76** — Proxy loop detection never triggers because marker header isn't added to outgoing requests
- **#77** — `connect run` SIGTERM handler can hang indefinitely (no timeout fallback like SIGINT has)
- **#78** — `/etc/hosts` marker matching uses `indexOf()` substring match, risking silent deletion of user entries

Also adds a CI smoke test for the agent CLI to catch startup crashes before release.

### Files changed

| File | Changes |
|------|---------|
| `apps/agent/src/cli.ts` | Add `.enablePositionalOptions()` (#74) |
| `apps/agent/src/active-routes.ts` | Add `validateServiceName()` to `registerRoute()` (#75) |
| `apps/agent/src/hosts.ts` | Newline filtering (#75), exact line matching for markers (#78) |
| `apps/agent/src/commands/proxy.ts` | Add marker header to outgoing requests, loop detection on upgrade/connect (#76) |
| `apps/agent/src/commands/run.ts` | Add 3s timeout to SIGTERM handler (#77) |
| `.github/workflows/ci.yml` | Add CLI smoke test step |
| `*/package.json` (×6) | Version bump 0.8.5 → 0.8.6 |

## Test plan

- [ ] `connect --version` outputs `0.8.6` (verifies #74 fix)
- [ ] `connect --help` lists all commands without crash
- [ ] `connect run` with invalid service name (e.g. containing newlines) is rejected with clear error (#75)
- [ ] Proxy forwards `x-private-connect-proxy` header on outgoing requests; looping request returns 508 (#76)
- [ ] `connect run api next dev` + SIGTERM exits within 3 seconds (#77)
- [ ] `/etc/hosts` sync ignores user comments containing marker text as substring (#78)
- [ ] CI smoke test step passes

Closes #74, closes #75, closes #76, closes #77, closes #78